### PR TITLE
Documented the modules

### DIFF
--- a/backend/modules/bloodGlucoseAnalysis/bloodGlucoseAnalysis.bal
+++ b/backend/modules/bloodGlucoseAnalysis/bloodGlucoseAnalysis.bal
@@ -1,5 +1,8 @@
-// backend/services/bloodGlucoseService.bal
-
+# Description.
+#
+# + fastingGlucose - fasting glucose level in mg/dL  
+# + randomGlucose - random glucose level in mg/dL
+# + hba1c - HbA1c level in percentage
 public type BloodGlucoseData record {
     float fastingGlucose;
     float randomGlucose;
@@ -11,6 +14,10 @@ type AnalysisResult record {
     string color;
 };
 
+# Description.
+#
+# + data - BloodGlucoseData record
+# + return - AnalysisResult array or error
 public isolated function analyzeBloodGlucose(BloodGlucoseData data) returns AnalysisResult[]|error  {
     AnalysisResult[] interpretations = [];
     
@@ -58,5 +65,5 @@ public isolated function analyzeBloodGlucose(BloodGlucoseData data) returns Anal
         });
     }
 
-    return interpretations; // Return the analysis results as JSON
+    return interpretations;
 }

--- a/backend/modules/crpAnalysis/crpAnalysis.bal
+++ b/backend/modules/crpAnalysis/crpAnalysis.bal
@@ -1,3 +1,6 @@
+# Description.
+#
+# + crpLevel - C-reactive protein level
 public type CRPData record {
     float crpLevel;
 };
@@ -8,6 +11,10 @@ type AnalysisResult record {
 };
 
 
+# Description.
+#
+# + data - CRPData record
+# + return - AnalysisResult array or error
 public isolated function analyzeCRP(CRPData data) returns AnalysisResult[]|error {
     AnalysisResult[] interpretations = [];
 
@@ -29,5 +36,5 @@ public isolated function analyzeCRP(CRPData data) returns AnalysisResult[]|error
         });
     }
 
-    return interpretations; // Return the analysis results as JSON
+    return interpretations;
 }

--- a/backend/modules/fbcAnalysis/fbcAnalysis.bal
+++ b/backend/modules/fbcAnalysis/fbcAnalysis.bal
@@ -1,5 +1,10 @@
 
-// Define the data model for FBC input
+# Description.
+#
+# + whiteBloodCells - white blood cell count
+# + redBloodCells - red blood cell count 
+# + platelets - platelet count
+# + hemoglobin - hemoglobin level
 public type FBCData record {
     float whiteBloodCells;
     float redBloodCells;
@@ -12,6 +17,10 @@ type AnalysisResult record {
     string color;
 };
 
+# Description.
+#
+# + data - FBCData record
+# + return - AnalysisResult array or error
 public isolated function analyzeFBC(FBCData data) returns AnalysisResult[]|error {
     AnalysisResult[] interpretations = [];
 
@@ -75,5 +84,5 @@ public isolated function analyzeFBC(FBCData data) returns AnalysisResult[]|error
         interpretations.push({ text: "Platelet count is normal, indicating a healthy coagulation process.", color: "green" });
     }
 
-    return interpretations; // Return the analysis results as JSON
+    return interpretations;
 }

--- a/backend/modules/lipidPanelAnalysis/lipidPanelAnalysis.bal
+++ b/backend/modules/lipidPanelAnalysis/lipidPanelAnalysis.bal
@@ -1,9 +1,14 @@
-// Define the data model for Lipid Panel input
+# Description.
+#
+# + cholesterol - total cholesterol level
+# + triglycerides - triglycerides level 
+# + hdl - high density lipoprotein 
+# + ldl - low density lipoprotein
 public type LipidPanelData record {
     float cholesterol;
     float triglycerides;
-    float hdl; // High-Density Lipoprotein
-    float ldl; // Low-Density Lipoprotein
+    float hdl; 
+    float ldl; 
 };
 
 type AnalysisResult record {
@@ -11,6 +16,10 @@ type AnalysisResult record {
     string color;
 };
 
+# Description.
+#
+# + data - LipidPanelData record
+# + return - AnalysisResult array or error
 public isolated function analyzeLipidPanel(LipidPanelData data) returns AnalysisResult[]|error {
     AnalysisResult[] interpretations = [];
 
@@ -96,5 +105,5 @@ public isolated function analyzeLipidPanel(LipidPanelData data) returns Analysis
         });
     }
 
-    return interpretations; // Return the analysis results as JSON
+    return interpretations; 
 }

--- a/backend/modules/liverFunctionTestAnalysis/liverFunctionTestAnalysis.bal
+++ b/backend/modules/liverFunctionTestAnalysis/liverFunctionTestAnalysis.bal
@@ -1,9 +1,15 @@
 // Define the data model for LFT input
+# Description.
+#
+# + alt - Alanine Aminotransferase
+# + ast - Aspartate Aminotransferase 
+# + alp - Alkaline Phosphatase 
+# + bilirubin - Total Bilirubin
 public type LFTData record {
-    float alt;      // Alanine Aminotransferase
-    float ast;      // Aspartate Aminotransferase
-    float alp;      // Alkaline Phosphatase
-    float bilirubin; // Total Bilirubin
+    float alt;      
+    float ast;      
+    float alp;      
+    float bilirubin; 
 };
 
 type AnalysisResult record {
@@ -11,6 +17,10 @@ type AnalysisResult record {
     string color;
 };
 
+# Description.
+#
+# + data - LFTData record
+# + return - AnalysisResult array or error
 public isolated function analyzeLFT(LFTData data) returns AnalysisResult[]|error {
     AnalysisResult[] interpretations = [];
 
@@ -66,5 +76,5 @@ public isolated function analyzeLFT(LFTData data) returns AnalysisResult[]|error
         });
     }
 
-    return interpretations; // Return the analysis results as JSON
+    return interpretations; 
 }

--- a/backend/modules/thyroidFunctionTestAnalysis/thyroidFunctionTestAnalysis.bal
+++ b/backend/modules/thyroidFunctionTestAnalysis/thyroidFunctionTestAnalysis.bal
@@ -1,8 +1,13 @@
-public // Define the data model for TFT input
+# Description.
+#
+# + tsh - thyroid-stimulating hormone level
+# + t3 - triiodothyronine level
+# + t4 - thyroxine level
+public 
 type TFTData record {
-    float tsh; // Thyroid Stimulating Hormone
-    float t3;  // Triiodothyronine
-    float t4;  // Thyroxine
+    float tsh; 
+    float t3;  
+    float t4;  
 };
 
 type AnalysisResult record {
@@ -10,6 +15,10 @@ type AnalysisResult record {
     string color;
 };
 
+# Description.
+#
+# + data - TFTData record
+# + return - AnalysisResult array or error
 public isolated function analyzeTFT(TFTData data) returns AnalysisResult[]|error {
     AnalysisResult[] interpretations = [];
 


### PR DESCRIPTION
This pull request includes extensive updates to the documentation of various data models and analysis functions across multiple modules in the backend. The primary goal is to add descriptions for the fields and return types of these functions and records.

### Documentation Updates:

* `backend/modules/bloodGlucoseAnalysis/bloodGlucoseAnalysis.bal`:
  * Added descriptions for `BloodGlucoseData` fields: `fastingGlucose`, `randomGlucose`, `hba1c`.
  * Added descriptions for `analyzeBloodGlucose` function parameters and return type.

* `backend/modules/crpAnalysis/crpAnalysis.bal`:
  * Added descriptions for `CRPData` field: `crpLevel`.
  * Added descriptions for `analyzeCRP` function parameters and return type.

* `backend/modules/fbcAnalysis/fbcAnalysis.bal`:
  * Added descriptions for `FBCData` fields: `whiteBloodCells`, `redBloodCells`, `platelets`, `hemoglobin`.
  * Added descriptions for `analyzeFBC` function parameters and return type.

* `backend/modules/lipidPanelAnalysis/lipidPanelAnalysis.bal`:
  * Added descriptions for `LipidPanelData` fields: `cholesterol`, `triglycerides`, `hdl`, `ldl`.
  * Added descriptions for `analyzeLipidPanel` function parameters and return type.

* `backend/modules/liverFunctionTestAnalysis/liverFunctionTestAnalysis.bal`:
  * Added descriptions for `LFTData` fields: `alt`, `ast`, `alp`, `bilirubin`.
  * Added descriptions for `analyzeLFT` function parameters and return type.

* `backend/modules/thyroidFunctionTestAnalysis/thyroidFunctionTestAnalysis.bal`:
  * Added descriptions for `TFTData` fields: `tsh`, `t3`, `t4`.
  * Added descriptions for `analyzeTFT` function parameters and return type.